### PR TITLE
fix: predict threshold null

### DIFF
--- a/app/services/anomalib_service.py
+++ b/app/services/anomalib_service.py
@@ -87,17 +87,9 @@ class AnomalibService:
                 except Exception:
                     pred_label = None
 
-            # threshold（まずは pred.threshold があればそれを使う）
+            # threshold（normalized_image_threshold のみを採用。無ければ None）
             threshold = None
-            if hasattr(pred, "threshold"):
-                try:
-                    th = pred.threshold
-                    threshold = float(th.reshape(-1)[0].item()) if hasattr(th, "numel") else float(th)
-                except Exception:
-                    threshold = None
-
-            # pred に無ければ post_processor から取得（normalized を優先）
-            if threshold is None and hasattr(self.model, "post_processor"):
+            if hasattr(self.model, "post_processor"):
                 pp = self.model.post_processor
                 # 1) normalized_image_threshold があれば最優先（pred_scoreとスケールが合う想定）
                 if hasattr(pp, "normalized_image_threshold"):
@@ -106,13 +98,6 @@ class AnomalibService:
                         threshold = float(nth.reshape(-1)[0].item()) if hasattr(nth, "numel") else float(nth)
                     except Exception:
                         threshold = None
-                # # 2) 無ければ raw を fallback（ただし pred_score と比較しない前提）
-                # if threshold is None and hasattr(pp, "image_threshold"):
-                #     try:
-                #         ith = pp.image_threshold
-                #         threshold = float(ith.reshape(-1)[0].item()) if hasattr(ith, "numel") else float(ith)
-                #     except Exception:
-                #         threshold = None
 
             if not hasattr(pred, "anomaly_map"):
                 raise RuntimeError("Prediction does not include anomaly_map")

--- a/app/services/anomalib_service.py
+++ b/app/services/anomalib_service.py
@@ -87,7 +87,7 @@ class AnomalibService:
                 except Exception:
                     pred_label = None
 
-            # threshold（無い場合あり）
+            # threshold（まずは pred.threshold があればそれを使う）
             threshold = None
             if hasattr(pred, "threshold"):
                 try:
@@ -95,6 +95,24 @@ class AnomalibService:
                     threshold = float(th.reshape(-1)[0].item()) if hasattr(th, "numel") else float(th)
                 except Exception:
                     threshold = None
+
+            # pred に無ければ post_processor から取得（normalized を優先）
+            if threshold is None and hasattr(self.model, "post_processor"):
+                pp = self.model.post_processor
+                # 1) normalized_image_threshold があれば最優先（pred_scoreとスケールが合う想定）
+                if hasattr(pp, "normalized_image_threshold"):
+                    try:
+                        nth = pp.normalized_image_threshold
+                        threshold = float(nth.reshape(-1)[0].item()) if hasattr(nth, "numel") else float(nth)
+                    except Exception:
+                        threshold = None
+                # # 2) 無ければ raw を fallback（ただし pred_score と比較しない前提）
+                # if threshold is None and hasattr(pp, "image_threshold"):
+                #     try:
+                #         ith = pp.image_threshold
+                #         threshold = float(ith.reshape(-1)[0].item()) if hasattr(ith, "numel") else float(ith)
+                #     except Exception:
+                #         threshold = None
 
             if not hasattr(pred, "anomaly_map"):
                 raise RuntimeError("Prediction does not include anomaly_map")

--- a/app/services/gpt_service.py
+++ b/app/services/gpt_service.py
@@ -58,10 +58,41 @@ class GPTService:
     def _max_risk(a: Literal["low", "medium", "high"], b: Literal["low", "medium", "high"]) -> Literal["low", "medium", "high"]:
         return a if _FALSE_POSITIVE_ORDER[a] >= _FALSE_POSITIVE_ORDER[b] else b
 
+    @staticmethod
+    def _label_to_has_anomaly(pred_label: Any) -> Optional[bool]:
+        """
+        pred_label の表現ゆれを吸収して has_anomaly(bool) に変換する。
+        変換できない場合は None を返し、別ロジックにフォールバックする。
+        """
+        if pred_label is None:
+            return None
+
+        # bool は int のサブクラスなので先に判定
+        if isinstance(pred_label, bool):
+            return bool(pred_label)
+
+        # 数値
+        if isinstance(pred_label, (int, float)):
+            if pred_label == 1:
+                return True
+            if pred_label == 0:
+                return False
+            return None
+
+        # 文字列
+        s = str(pred_label).strip().lower()
+        if s in {"1", "true", "t", "yes", "y", "anomaly", "abnormal", "positive", "defect"}:
+            return True
+        if s in {"0", "false", "f", "no", "n", "normal", "ok", "negative"}:
+            return False
+
+        return None
+
     def _postprocess_structured(
         self,
         *,
         parsed: VLMAnomalyExplanation,
+        pred_label: Optional[str],
         pred_score: Optional[float],
         threshold: Optional[float],
         max_hypotheses: int = 3,
@@ -70,13 +101,30 @@ class GPTService:
         """
         サーバ側で “確実に” 制約と整合性を担保する。
         - hypotheses/checks の最大件数を強制
-        - pred_score と threshold がある場合、has_anomaly を境界と整合させる
+        - pred_label がある場合、has_anomaly をこれに合わせる。
+        - pred_label がない、かつ pred_score と threshold がある場合、has_anomaly を境界と整合させる
         """
         # 1) 件数制限
         parsed.hypotheses = self._clip_list(parsed.hypotheses, max_hypotheses)
         parsed.checks = self._clip_list(parsed.checks, max_checks)
 
-        # 2) pred_score/threshold 整合チェック（両方ある時のみ）
+        # 2) pred_label がある場合は最優先で has_anomaly を整合させる
+        if pred_label is not None:
+            suggested = self._label_to_has_anomaly(pred_label)
+
+            # 解釈不能なら pred_label 補正はスキップして fallback に回す
+            if suggested is not None:
+                if parsed.has_anomaly != suggested:
+                    reason = (
+                        f"[consistency_fix] has_anomaly was {parsed.has_anomaly} "
+                        f"but adjusted to {suggested} because pred_label={pred_label}."
+                    )
+                    notes = (parsed.notes or "").strip()
+                    parsed.notes = (notes + "\n" + reason).strip() if notes else reason
+                    parsed.has_anomaly = suggested
+                return parsed
+
+        # 3) pred_score/threshold 整合チェック（両方ある時のみ）
         if pred_score is not None and threshold is not None:
             suggested = pred_score >= threshold
             if parsed.has_anomaly != suggested:
@@ -163,11 +211,13 @@ class GPTService:
             # パースできない場合は例外にして気づけるようにする（PoCでは早期検知優先）
             raise ValueError("Structured output parsing failed (output_parsed is None).")
 
+        pred_label = anomaly.get("pred_label")
         pred_score = anomaly.get("pred_score")
         threshold = anomaly.get("threshold")
 
         return self._postprocess_structured(
             parsed=parsed,
+            pred_label=pred_label,
             pred_score=pred_score,
             threshold=threshold,
             max_hypotheses=3,


### PR DESCRIPTION
# 目的
- `/anomaly/predict` の出力の `threshold` が `null` になるのでこれを修正。#13
- VLM出力後の整合性を担保する処理ロジックの更新

# 変更点
- `/anomaly/predict` では、`pred_score` に合わせて `threshold` として**正規化した閾値**を出力する
- `/anomaly/explain` では、has_anomaly` の値は、
  - `異常検知結果`pred_label` を優先的に見て、異なる場合はこの値に合わせるように修正。
  - `pred_label` がない場合は、`pred_score` と `threshold` の比較結果に合わせるように修正。
  - `pred_score` か `threshold` がない場合は `None` にする。

# 動作確認
- `/anomaly/predit` の出力として、`"threshold":<float値>` が返ってくることを確認。
- `/anomaly/explain` をたたいて、`"has_anomaly":true` が返ってくることを確認。

後者については、正常系（異常検知結果に `pred_label` が存在して、VLM出力の `has_anomaly` と最初から一致している場合）に副作用がないか確認となる。
そのため、2つ目の変更点は異常系（異常検知結果に `pred_label` が存在しない場合など）であるため動作の確認はしていない。
