### PR TITLE
chore: setup AI agent env safety

### DIFF
--- a/.cursor/rules/project.mdc
+++ b/.cursor/rules/project.mdc
@@ -1,0 +1,11 @@
+---
+description: Rules for Cursor Agent in AnomalyReportGenerator
+alwaysApply: true
+---
+
+- Follow `AGENTS.md` when working in this repository.
+- Never access `.env` or `.env.*`.
+- Use `.env.example` only.
+- Do not modify `datasets/`, `models/`, or `results/` unless explicitly requested.
+- Prefer small, reviewable diffs.
+- Ask before running expensive commands, training, GPU-heavy inference, or commands that may call external APIs.

--- a/.cursorignore
+++ b/.cursorignore
@@ -1,0 +1,11 @@
+.env
+.env.*
+!.env.example
+
+models/
+datasets/
+results/
+*.ckpt
+*.pt
+*.pth
+*.onnx

--- a/.cursorignore
+++ b/.cursorignore
@@ -1,6 +1,21 @@
-.env
-.env.*
-!.env.example
+# .env はAIエージェント用のダミー値として見せる
+# .env.example も見せる
+
+# ただし、派生envファイルは見せない
+.env.local
+.env.production
+.env.secret
+.env.real
+*.key
+*.pem
+
+datasets/
+models/
+results/
+*.ckpt
+*.pt
+*.pth
+*.onnx
 
 models/
 datasets/

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 .idea/
 
 # ===== Anomalib output =====
+models/
+datasets/
 results/
 
 # ===== Temp images =====

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,28 @@
+# AGENTS.md
+
+## Project
+AnomalyReportGenerator is a FastAPI-based anomaly report generation project using Anomalib and OpenAI VLM structured outputs.
+
+## Security
+- Never read, print, edit, summarize, or copy `.env` or `.env.*`.
+- Use `.env.example` only to understand required environment variables.
+- Never expose API keys, tokens, credentials, or secrets.
+- Never run commands that print environment variables, such as `env`, `printenv`, `set`, `Get-ChildItem Env:`, or `echo $env:OPENAI_API_KEY`.
+
+## Files to Avoid
+- Do not modify `datasets/`, `models/`, or `results/` unless explicitly requested.
+- Do not modify large binary files or model checkpoints.
+- Do not commit generated files unless explicitly requested.
+
+## Development Style
+- Prefer small, focused changes.
+- Explain the planned change before large refactors.
+- Keep API responses backward-compatible unless explicitly requested.
+- Update README when commands, API behavior, or setup steps change.
+
+## Project Commands
+Install dependencies in this order:
+```bash
+pip install -r requirements-torch-cu121.txt
+pip install -r requirements-anomalib.txt
+pip install -r requirements.txt

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,8 +1,11 @@
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from pydantic import Field
+import os
+
+ENV_FILE_PATH = os.getenv("ENV_FILE_PATH", ".env")
 
 class Settings(BaseSettings):
-    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
+    model_config = SettingsConfigDict(env_file=ENV_FILE_PATH, env_file_encoding="utf-8")
 
     # Anomalib (Engine)
     anomalib_ckpt_path: str = Field(default="./models/model.ckpt", alias="ANOMALIB_CKPT_PATH")


### PR DESCRIPTION
## 概要

#22 の対応。

AIエージェント（Cursor / Codex）を用いた開発を安全に進めるため、開発環境まわりの設定を整理しました。

主な対応内容は以下です。

- `.gitignore` の整理
- `.cursorignore` の追加
- AIエージェント向けに参照可能なファイル範囲の整理
- `.env` 読み込み処理に `ENV_FILE_PATH` を追加
- プロジェクト内 `.env` と本物の秘密情報を分離する運用方針の整理

## 背景

今後、Cursor / Codex を利用してAI駆動開発を行う予定です。

その際、AIエージェントにはプロジェクト構成や環境変数名を理解させたい一方で、OpenAI APIキーなどの本物の秘密情報は読み込ませたくありません。

そのため、以下の運用を前提とします。

- `.env.example` は従来どおりGit管理する
- `.env` は従来どおりGit管理しない
- プロジェクト内の `.env` はAIエージェント確認用のダミー値のみを記載する
- 本物のAPIキーを含む `.env` はプロジェクトフォルダ外で管理する
- 実際にアプリを動かす場合のみ、`ENV_FILE_PATH` で外部 `.env` を指定する

## 設計方針

通常利用時の挙動は従来どおり、プロジェクト直下の `.env` を読み込む構成とします。
ただし、AIエージェントもこの `.env` を読み込むため、APIキーはダミーを設定しています。

```bash
uvicorn app.main:app --host 127.0.0.1 --port 8000 --workers 1
```

一方、自分のローカル環境で本物のAPIキーを使って実行する場合は、以下のように外部 .env を指定します。
```bash
$env:ENV_FILE_PATH="<プロジェクトフォルダ外に配置した本物のAPIキーが記述された.envファイルのパス>"
uvicorn app.main:app --host 127.0.0.1 --port 8000 --workers 1
```